### PR TITLE
Update lock.js

### DIFF
--- a/lib/lock.js
+++ b/lib/lock.js
@@ -25,7 +25,7 @@ function Lock(peripheral, offlineKey, offlineKeyOffset) {
 }
 
 // service uuid, exposed for scanning
-Lock.BLE_COMMAND_SERVICE = "bd4ac6100b4511e38ffd0800200c9a66";
+Lock.BLE_COMMAND_SERVICE = "fe24";
 
 Lock.prototype.connect = function() {
   var handshakeKeys = crypto.randomBytes(16);


### PR DESCRIPTION
August Smart Lock 3rd Generation GATT Profile is different from the one used here. When Noble scans for the lock by service UUID, it needs to look for the new updated service uuid which is a SIG (not vendor defined) Service UUID "fe24".